### PR TITLE
Update to use examples that exist

### DIFF
--- a/openfisca_nsw/__init__.py
+++ b/openfisca_nsw/__init__.py
@@ -27,7 +27,7 @@ class CountryTaxBenefitSystem(TaxBenefitSystem):
 
         # We define which variable, parameter and simulation example will be used in the OpenAPI specification
         self.open_api_config = {
-            "variable_example": "disposable_income",
-            "parameter_example": "taxes.income_tax_rate",
+            "variable_example": "active_kids__child_meets_criteria",
+            "parameter_example": "active_kids.min_age",
             "simulation_example": couple,
             }


### PR DESCRIPTION
The app isn't starting on Heroku.
This may fix the error.

```
2019-02-26T04:39:47.994539+00:00 app[web.1]: self.options.get('welcome_message')
2019-02-26T04:39:47.994541+00:00 app[web.1]: File "/app/.heroku/python/lib/python3.6/site-packages/openfisca_web_api/app.py", line 62, in create_app
2019-02-26T04:39:47.994543+00:00 app[web.1]: data = build_data(tax_benefit_system)
2019-02-26T04:39:47.994545+00:00 app[web.1]: File "/app/.heroku/python/lib/python3.6/site-packages/openfisca_web_api/loader/__init__.py", line 23, in build_data
2019-02-26T04:39:47.994547+00:00 app[web.1]: data['openAPI_spec'] = build_openAPI_specification(data)
2019-02-26T04:39:47.994550+00:00 app[web.1]: File "/app/.heroku/python/lib/python3.6/site-packages/openfisca_web_api/loader/spec.py", line 43, in build_openAPI_specification
2019-02-26T04:39:47.994552+00:00 app[web.1]: parameter_example = api_data['parameters'][parameter_path]
2019-02-26T04:39:47.994554+00:00 app[web.1]: KeyError: 'taxes/income_tax_rate'
```