### PR TITLE
Feature/birth date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,19 @@
 # Changelog
 
+### 0.2.2 - [#12](https://github.com/digitalnsw/openfisca-nsw/pull/12)
 
-### 0.2.1 - [#8](https://github.com/openfisca/country-template/pull/8)
+* Tax and benefit system evolution. 
+  - Corrected Active Kids max age cutoff to 19 years
+* Technical improvement.
+  - Change max and min age parameters for Active Kids to be in years, not months
+  - Active Kids tests using birth date instead of age_in_months
+
+### 0.2.1 - [#8](https://github.com/digitalnsw/openfisca-nsw/pull/8)
 
 * Tax and benefit system evolution.
  - Added medicare card to eligibility criteria for Active Kids
 
-
-### 0.2.0 - [#4](https://github.com/openfisca/country-template/pull/4)
+### 0.2.0 - [#4](https://github.com/digitalnsw/openfisca-nsw/pull/4)
 
 * Tax and benefit system evolution.
   - Added variables based on birth day: `age_in_months`, `is_birthday_past`, `birth_month`
@@ -18,12 +24,12 @@
     - `active_kids__family_has_children_eligible`
     - `active_kids__is_eligible`
 
-### 0.1.1 - [#2](https://github.com/openfisca/country-template/pull/2)
+### 0.1.1 - [#2](https://github.com/digitalnsw/openfisca-nsw/pull/2)
 
 * Technical improvement
   - Remove deployment from circle-ci
 
-### 0.1.0 - [#1](https://github.com/openfisca/country-template/pull/1)
+### 0.1.0 - [#1](https://github.com/digitalnsw/openfisca-nsw/pull/1)
 
 * Technical improvement
   - Circle ci config

--- a/openfisca_nsw/parameters/active_kids/max_age.yaml
+++ b/openfisca_nsw/parameters/active_kids/max_age.yaml
@@ -1,5 +1,5 @@
 description: Maximum age of a child required to be eligible for Active Kids vouchers
-reference: TODO
+reference: Page 5, Eligibility Criteria, Active Kids Program Recipient Guidelines https://sportandrecreation.nsw.gov.au/sites/default/files/Active_Kids_Recipient_Guidelines_20171119.pdf
 values:
   2018-01-31:
     value: 19

--- a/openfisca_nsw/parameters/active_kids/max_age.yaml
+++ b/openfisca_nsw/parameters/active_kids/max_age.yaml
@@ -2,4 +2,4 @@ description: Maximum age of a child required to be eligible for Active Kids vouc
 reference: TODO
 values:
   2018-01-31:
-    value: 216
+    value: 19

--- a/openfisca_nsw/parameters/active_kids/min_age.yaml
+++ b/openfisca_nsw/parameters/active_kids/min_age.yaml
@@ -1,5 +1,5 @@
 description: Minimum age of a child required to be eligible for Active Kids vouchers
-reference: TODO
+reference: Page 5, Eligibility Criteria, Active Kids Program Recipient Guidelines https://sportandrecreation.nsw.gov.au/sites/default/files/Active_Kids_Recipient_Guidelines_20171119.pdf
 values:
   2018-01-31:
-    value: 54
+    value: 4.5

--- a/openfisca_nsw/parameters/active_kids/voucher.yaml
+++ b/openfisca_nsw/parameters/active_kids/voucher.yaml
@@ -1,5 +1,5 @@
 description: Voucher value in AUD for Active Kids voucher
-reference: TODO
+reference: https://sportandrecreation.nsw.gov.au/sites/default/files/Active_Kids_Recipient_Guidelines_20171119.pdf
 values:
   2018-01-31:
     value: 100

--- a/openfisca_nsw/tests/active_kids/families.yaml
+++ b/openfisca_nsw/tests/active_kids/families.yaml
@@ -1,4 +1,4 @@
-- name: Entitled Parent applicant
+- name: Entitled Parent applicant, living with Aunty
   period: 2019-01
   input:
     persons:
@@ -7,9 +7,9 @@
       child1:
         is_nsw_resident: True
         is_enrolled_in_school: True
-        age_in_months: 100
+        birth: 2014-01-01
       aunty:
-        age: 25
+        is_nsw_resident: True
     families:
       smith:
         parents: [parent1]
@@ -20,7 +20,10 @@
       - False
       - True
       - False
-    active_kids__voucher_amount: [ 0, 100, 0 ]
+    active_kids__voucher_amount:
+      - 0
+      - 100
+      - 0
     active_kids__is_eligible:
       - True
       - False # The child is not a parent, so not eligible
@@ -35,15 +38,15 @@
       child1:
         is_nsw_resident: True
         is_enrolled_in_school: True
-        age_in_months: 100
+        birth: 2014-01-01
     families:
       family1:
         parents: [parent1]
         children: [child1]
   output:
     active_kids__child_meets_criteria:
-      - False #parent
-      - True #child
+      - False # parent
+      - True  # child
     active_kids__is_eligible:
       - True
       - False 
@@ -57,7 +60,7 @@
       child1:
         is_nsw_resident: True
         is_enrolled_in_school: True
-        age_in_months: 100
+        birth: 2014-01-01
     families:
       family1:
         parents: [parent1]

--- a/openfisca_nsw/tests/active_kids/meets_criteria.yaml
+++ b/openfisca_nsw/tests/active_kids/meets_criteria.yaml
@@ -47,7 +47,7 @@
     is_nsw_resident: True
     has_valid_medicare_card: True
     is_enrolled_in_school: True
-    birth: 2018-01
+    birth: 2018-01-03
   output:
     active_kids__child_meets_criteria: False
 
@@ -57,6 +57,6 @@
     is_nsw_resident: True
     has_valid_medicare_card: True
     is_enrolled_in_school: True
-    birth: 2001-01
+    birth: 2000-01-01
   output:
     active_kids__child_meets_criteria: False

--- a/openfisca_nsw/tests/active_kids/meets_criteria.yaml
+++ b/openfisca_nsw/tests/active_kids/meets_criteria.yaml
@@ -3,7 +3,7 @@
   input:
     is_nsw_resident: True
     is_enrolled_in_school: True
-    age_in_months: 100
+    birth: 2014-01-01
   output:
     active_kids__child_meets_criteria: True
     active_kids__voucher_amount: 100
@@ -13,7 +13,7 @@
   input:
     is_nsw_resident: False
     is_enrolled_in_school: True
-    age_in_months: 100
+    birth: 2014-01-01
   output:
     active_kids__child_meets_criteria: False
     active_kids__voucher_amount: 0
@@ -23,7 +23,7 @@
   input:
     is_nsw_resident: True
     is_enrolled_in_school: False
-    age_in_months: 100
+    birth: 2014-01-01
   output:
     active_kids__child_meets_criteria: False
 
@@ -32,7 +32,7 @@
   input:
     is_nsw_resident: True
     is_enrolled_in_school: True
-    age_in_months: 50
+    birth: 2018-01
   output:
     active_kids__child_meets_criteria: False
 
@@ -41,6 +41,6 @@
   input:
     is_nsw_resident: True
     is_enrolled_in_school: True
-    age_in_months: 217
+    birth: 2001-01
   output:
     active_kids__child_meets_criteria: False

--- a/openfisca_nsw/tests/age/years.yaml
+++ b/openfisca_nsw/tests/age/years.yaml
@@ -38,3 +38,21 @@
       2015-02: 34
       2015-03: 35
 
+- name: Ages in a family
+  period: 2016-01
+  input:
+    persons:
+      parent1:
+        birth: 2000-01-01
+      child1:
+        birth: 2014-01-01
+      aunty:
+        birth: 2014-01-01
+    families:
+      smith:
+        parents: [parent1]
+        children: [child1]
+        others: [aunty]
+  output:
+    age: [16, 2, 2]
+    age_in_months: [192, 24, 24]

--- a/openfisca_nsw/variables/policy/active_kids.py
+++ b/openfisca_nsw/variables/policy/active_kids.py
@@ -29,14 +29,14 @@ class active_kids__child_meets_criteria(Variable):
     reference = 'https://sport.nsw.gov.au/sectordevelopment/activekids'
 
     def formula(persons, period, parameters):
-        min_age = parameters(period).active_kids.min_age
-        max_age = parameters(period).active_kids.max_age
-        age = persons('age_in_months', period)
+        min_age_in_months = 12 * parameters(period).active_kids.min_age
+        max_age_in_months = 12 * parameters(period).active_kids.max_age
+        age_in_months = persons('age_in_months', period)
         return (
             persons('is_nsw_resident', period) *
             persons('is_enrolled_in_school', period) *
             persons('has_valid_medicare_card', period) *
-            (age >= min_age) * (age < max_age)
+            (age_in_months >= min_age_in_months) * (age_in_months < max_age_in_months)
             )
 
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-nsw",
-    version = "0.2.1",
+    version = "0.2.2",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.org",
     classifiers=[


### PR DESCRIPTION
* Tax and benefit system evolution. 
  - Corrected Active Kids max age cutoff to 19 years
* Technical improvement.
  - Change max and min age parameters for Active Kids to be in years, not months
  - Active Kids tests using birth date instead of age_in_months
